### PR TITLE
Update the README file with Illumina reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ PROJECT=<GCP Project name>
 # create storage bucket for test
 gcloud storage buckets --project $PROJECT create gs://$BUCKET_NAME
 
-#method 1 - use storage trasnfer service
+#method 1 - use storage transfer service
 
 # There is already a public sample data bucket in GCS with reference from Illumina. 
 # IAM - give the project-<project-id>@@storage-transfer-service.iam.gserviceaccount.com role: Storage Legacy Bucket Writer

--- a/README.md
+++ b/README.md
@@ -9,22 +9,67 @@ This project enables Google Batch processing of Illumina DRAGEN pipelines on Evi
 *Note: Illumina sample files are ~90GB*
 
 ```bash
+#!/bin/bash
+
 # Google Cloud Storage bucket for testing
-BUCKET_NAME=
+BUCKET_NAME=<GCS bucket name>
 # Google Cloud project
-PROJECT=
-# get sample files
-mkdir batch-test && cd batch-test
-wget https://ilmn-dragen-giab-samples.s3.amazonaws.com/WGS/precisionFDA_v2_HG002/HG002.novaseq.pcr-free.35x.R1.fastq.gz
-wget https://ilmn-dragen-giab-samples.s3.amazonaws.com/WGS/precisionFDA_v2_HG002/HG002.novaseq.pcr-free.35x.R2.fastq.gz
-mkdir v8 && cd v8
-wget https://ilmn-dragen-giab-samples.s3.amazonaws.com/Hashtable/hg38_altaware-cnv-graph-anchored.v8.tar
-tar -xf hg38_altaware-cnv-graph-anchored.v8.tar && rm hg38_altaware-cnv-graph-anchored.v8.tar && cd ..
+PROJECT=<GCP Project name>
+
 # create storage bucket for test
 gcloud storage buckets --project $PROJECT create gs://$BUCKET_NAME
+
+#method 1 - use storage trasnfer service
+
+# There is already a public sample data bucket in GCS with reference from Illumina. 
+# IAM - give the project-<project-id>@@storage-transfer-service.iam.gserviceaccount.com role: Storage Legacy Bucket Writer
+gcloud transfer jobs create gs://thomashk-public-illumina-sample gs://$BUCKET_NAME
+
+# method 2 - copy data from GCP sample bucket to the new bucket manaually:
+
+# get sample fastq files
+wget https://storage.googleapis.com/thomashk-public-illumina-sample/HG002.novaseq.pcr-free.35x.R1.fastq.gz
+wget https://storage.googleapis.com/thomashk-public-illumina-sample/HG002.novaseq.pcr-free.35x.R2.fastq.gz 
+
+# Downloading Illumina DRAGEN Multigenome Graph Reference - hg38
+# https://support.illumina.com/downloads/dragen-reference-genomes-hg38.html
+
+# Reference for DRAGEN v4.2 
+#mkdir 4_2_reference && cd 4_2_reference
+#wget https://webdata.illumina.com/downloads/software/dragen/references/genome-files/hg38-alt_masked.cnv.graph.hla.rna-9-r3.0-1.tar.gz
+#gunzip hg38-alt_masked.cnv.graph.hla.rna-9-r3.0-1.tar.gz
+#tar -xvf hg38-alt_masked.cnv.graph.hla.rna-9-r3.0-1.tar
+#cd ..
+# Reference for DRAGEN v4.0
+#mkdir 4_0_reference && cd 4_0_reference
+#wget https://webdata.illumina.com/downloads/software/dragen/hg38%2Balt_masked%2Bcnv%2Bgraph%2Bhla%2Brna-8-r2.0-1.run
+#./hg38%2Balt_masked%2Bcnv%2Bgraph%2Bhla%2Brna-8-r2.0-1.run
+#cd ..
+# Reference for DRAGEN v3.10
+#mkdir 3_10_reference && cd 3_10_reference
+#wget https://webdata.illumina.com/downloads/software/dragen/hg38_alt_masked_graph_v2%2Bcnv%2Bgraph%2Brna-8-1644018559-1.run
+#./hg38_alt_masked_graph_v2%2Bcnv%2Bgraph%2Brna-8-1644018559-1.run
+#cd ..
+# Reference for DRAGEN v3.9
+#mkdir 3_9_reference && cd 3_9_reference
+#https://webdata.illumina.com/downloads/software/dragen/genomes/hg38_alt_masked%2Bcnv%2Bgraph%2Brna-8-r1.0-1.run
+#./hg38_alt_masked%2Bcnv%2Bgraph%2Brna-8-r1.0-1.run
+#cd ..
+# Reference for DRAGEN v3.7 or older
+#mkdir 3_7_reference && cd 3_7_reference
+#wget https://s3.amazonaws.com/webdata.illumina.com/downloads/software/dragen/references/genome-files/hg38/hg38_alt_aware%2Bcnv%2Bgraph%2Brna-8-r1.0-0.run
+#./hg38_alt_aware%2Bcnv%2Bgraph%2Brna-8-r1.0-0.run
+#cd ..
+
+# Downloading the data from local to the GCS bucket:
 gcloud storage cp --project $PROJECT HG002.novaseq.pcr-free.35x.R1.fastq.gz gs://$BUCKET_NAME
 gcloud storage cp --project $PROJECT HG002.novaseq.pcr-free.35x.R2.fastq.gz gs://$BUCKET_NAME
-gcloud storage cp -r --project $PROJECT v8 gs://$BUCKET_NAME
+# select the reference needed and uncomment the line below:
+#gcloud storage cp -r --project $PROJECT 4_2_reference gs://$BUCKET_NAME
+#gcloud storage cp -r --project $PROJECT 4_0_reference gs://$BUCKET_NAME
+#gcloud storage cp -r --project $PROJECT 3_10_reference gs://$BUCKET_NAME
+#gcloud storage cp -r --project $PROJECT 3_9_reference gs://$BUCKET_NAME
+#gcloud storage cp -r --project $PROJECT 3_7_reference gs://$BUCKET_NAME
 ```
 
 2. [Create HMAC keys](https://cloud.google.com/storage/docs/authentication/managing-hmackeys)
@@ -32,6 +77,8 @@ gcloud storage cp -r --project $PROJECT v8 gs://$BUCKET_NAME
 3. Create Google Cloud Secrets
 
 ```bash
+#!/bin/bash
+
 # JARVICE credentials provided during onboarding
 JARVICE_API_USERNAME=
 JARVICE_API_APIKEY=
@@ -41,9 +88,9 @@ S3_SECRET_KEY=
 # Illumina license string
 ILLUMINA_LIC_SERVER=
 # Google cloud project
-PROJECT=
+PROJECT=<<GCP Project name>
 # Google Cloud zone used for testing (e.g. us-central1)
-ZONE=
+ZONE=us-central1
 
 printf "$JARVICE_API_USERNAME" | gcloud secrets create --project $PROJECT "jarviceApiUsername" --data-file=- --replication-policy=user-managed --locations=$ZONE
 printf "$JARVICE_API_APIKEY" | gcloud secrets create --project $PROJECT "jarviceApiKey" --data-file=- --replication-policy=user-managed --locations=$ZONE
@@ -52,64 +99,47 @@ printf "$S3_SECRET_KEY" | gcloud secrets create --project $PROJECT "batchS3Secre
 printf "$ILLUMINA_LIC_SERVER" | gcloud secrets create --project $PROJECT "illuminaLicServer" --data-file=- --replication-policy=user-managed --locations=$ZONE
 ```
 
-4. Prepare batch example
+4. Prepare batch example file - env.sh
 ```bash
-git clone https://github.com/nimbix/jarvice-dragen-batch
-cd jarvice-dragen-batch/examples
-# Google Cloud Storage bucket for testing
-BUCKET_NAME=""
-# Google Batch (https://cloud.google.com/batch) jobname
+# This is a sample env.sh file. Please update all the GCP project name and bucket name before using.
 NAME="sample-batch-job"
 # Google Cloud project
-PROJECT=""
+PROJECT="<GCP Project name>"
 # Google Cloud zone (e.g. us-central1)
-ZONE=""
-# list available versions with: ../tools/list-versions.sh
-VERSION=""
-# DRAGEN application (e.g "illumina-dragen_3_7_8n")
-JARVICE_DRAGEN_APP="illumina-dragen_3_7_8n"
-cat > env.sh <<EOF
-NAME="$NAME"
-# Google Cloud project
-PROJECT="$PROJECT"
-# Google Cloud zone (e.g. us-central1)
-ZONE="$ZONE"
+ZONE="us-central1"
 # Google Cloud service account
-SERVICE_ACCOUNT="default"
+SERVICE_ACCOUNT="<project id>-compute@developer.gserviceaccount.com"
 # list available versions with: ../tools/list-versions.sh
-VERSION="$VERSION"
+VERSION="1.0-rc.5"
 # DRAGEN application (e.g "illumina-dragen_3_7_8n")
-JARVICE_DRAGEN_APP="$JARVICE_DRAGEN_APP"
-JARVICE_API_USERNAME_SECRET="projects/${PROJECT}/secrets/jarviceApiUsername/versions/1"
-JARVICE_API_APIKEY_SECRET="projects/${PROJECT}/secrets/jarviceApiKey/versions/1"
-S3_ACCESS_KEY_SECRET="projects/${PROJECT}/secrets/batchS3AccessKey/versions/1"
-S3_SECRET_KEY_SECRET="projects/${PROJECT}/secrets/batchS3SecretKey/versions/1"
-ILLUMINA_LIC_SERVER_SECRET="projects/${PROJECT}/secrets/illuminaLicServer/versions/1"
+JARVICE_DRAGEN_APP="illumina-dragen_4_2_4n"
+JARVICE_API_USERNAME_SECRET="projects/<GCP Project name>/secrets/jarviceApiUsername/versions/latest"
+JARVICE_API_APIKEY_SECRET="projects/<GCP Project name>/secrets/jarviceApiKey/versions/latest"
+S3_ACCESS_KEY_SECRET="projects/<GCP Project name>/secrets/batchS3AccessKey/versions/latest"
+S3_SECRET_KEY_SECRET="projects/<GCP Project name>/secrets/batchS3SecretKey/versions/latest"
+ILLUMINA_LIC_SERVER_SECRET="projects/<GCP Project name>/secrets/illuminaLicServer/versions/latest"
 
 DRAGEN_ARGS=(
 -f
---enable-variant-caller true
---vc-emit-ref-confidence GVCF
---vc-enable-vcf-output true
---enable-duplicate-marking true
+-r s3://<GCS Bucket name>/4_2_reference
+-1 s3://<GCS Bucket name>/HG002.novaseq.pcr-free.35x.R1.fastq.gz
+-2 s3://<GCS Bucket name>/HG002.novaseq.pcr-free.35x.R2.fastq.gz
+--RGID HG002 
+--RGSM HG002 
+--output-directory s3://<GCP Bucket name>/output2
+--output-file-prefix HG002_4_2
 --enable-map-align true
 --enable-map-align-output true
+--output-format CRAM
+--enable-duplicate-marking true
+--enable-variant-caller true
+--vc-enable-vcf-output true
+--vc-emit-ref-confidence GVCF
 --vc-frd-max-effective-depth 40
 --vc-enable-joint-detection true
---ht-alt-aware-validate false
 --read-trimmers polyg
 --soft-read-trimmers none
---logging-to-output-dir true
--1 s3://$BUCKET_NAME/HG002.novaseq.pcr-free.35x.R1.fastq.gz
--2 s3://$BUCKET_NAME/HG002.novaseq.pcr-free.35x.R2.fastq.gz
---RGID HG002
---RGSM HG002
--r s3://$BUCKET_NAME/v8
---output-file-prefix HG002_pure
---output-format CRAM
---output-directory s3://$BUCKET_NAME/output
 )
-EOF
 ```
 5. Run example
 ```bash

--- a/README.md
+++ b/README.md
@@ -50,11 +50,6 @@ wget https://storage.googleapis.com/thomashk-public-illumina-sample/HG002.novase
 #wget https://webdata.illumina.com/downloads/software/dragen/hg38_alt_masked_graph_v2%2Bcnv%2Bgraph%2Brna-8-1644018559-1.run
 #./hg38_alt_masked_graph_v2%2Bcnv%2Bgraph%2Brna-8-1644018559-1.run
 #cd ..
-# Reference for DRAGEN v3.9
-#mkdir 3_9_reference && cd 3_9_reference
-#https://webdata.illumina.com/downloads/software/dragen/genomes/hg38_alt_masked%2Bcnv%2Bgraph%2Brna-8-r1.0-1.run
-#./hg38_alt_masked%2Bcnv%2Bgraph%2Brna-8-r1.0-1.run
-#cd ..
 # Reference for DRAGEN v3.7 or older
 #mkdir 3_7_reference && cd 3_7_reference
 #wget https://s3.amazonaws.com/webdata.illumina.com/downloads/software/dragen/references/genome-files/hg38/hg38_alt_aware%2Bcnv%2Bgraph%2Brna-8-r1.0-0.run
@@ -88,7 +83,7 @@ S3_SECRET_KEY=
 # Illumina license string
 ILLUMINA_LIC_SERVER=
 # Google cloud project
-PROJECT=<<GCP Project name>
+PROJECT=<GCP Project name>
 # Google Cloud zone used for testing (e.g. us-central1)
 ZONE=us-central1
 


### PR DESCRIPTION
I updated the the README file with the updated Illumina reference file. As we moved to the different versions of reference file. These reference files / directory need to be updated as well. Provided different versions in the download script. or user can just copy from my public facing bucket.

I also converted the command approach into the script approach. it is more convenience on my end and I have no objection to use the command approach. 

I also took out the bucket name variable at the env.sh. User needs to be aware that they have to update the access keys when using a different bucket. We can discuss if there is a better approach here.    